### PR TITLE
Add some APIs flags and triggers over mqtt

### DIFF
--- a/ledPatterns/ProjectAlicePattern.py
+++ b/ledPatterns/ProjectAlicePattern.py
@@ -28,9 +28,9 @@ class ProjectAlicePattern(LedPattern):
 		self.off()
 		self._animator.doubleSidedFilling(color=[255, 255, 255, 15], startAt=start, direction=1, speed=50)
 		time.sleep(0.1)
-		self._animator.doubleSidedFilling(color=[0, 0, 255, 25], startAt=start, direction=-1, speed=50)
+		self._animator.doubleSidedFilling(color=[0, 0, 255, 25], startAt=start, direction=-1, speed=50, new=False)
 		time.sleep(0.2)
-		self._animator.doubleSidedFilling(color=[0, 0, 0, 0], startAt=start, direction=1, speed=50)
+		self._animator.doubleSidedFilling(color=[0, 0, 0, 0], startAt=start, direction=1, speed=50, new=False)
 
 
 	def listen(self, *args):

--- a/models/Animations.py
+++ b/models/Animations.py
@@ -21,6 +21,30 @@ class Animations:
 			self._image = [[0, 0, 0, 0] for _ in range(self._numLeds)]
 
 
+	def rainbow(self, brightness=255, speed=100):
+		rainbowColors = [
+			[255, 0, 0], 	# RED
+			[255, 127, 0], 	# ORANGE
+			[255, 255, 0],	# YELLOW
+			[0, 255, 0], 	# GREEN
+			[0, 255, 127], 	# LIME
+			[0, 255, 255],	# CYAN
+			[0, 0, 255],	# BLUE
+			[127, 0, 255],	# PURPLE
+			[255, 0, 255], 	# PINK
+			[255, 0, 127],	# FUCHSIA
+		]
+
+		self._animationFlag.set()
+
+		while self._animationFlag.isSet():
+			for color in rainbowColors:
+				for ledX in range(0, self._numLeds):
+					self._controller.setLedRGB(ledX, [color[0], color[1], color[2]], brightness)
+					time.sleep(1.0 / abs(speed))
+					self._controller.show()
+
+
 	def doubleSidedFilling(self, color, startAt=0, direction=1, speed=10):
 		"""
 		Fills the strip from both sides

--- a/models/Animations.py
+++ b/models/Animations.py
@@ -278,7 +278,7 @@ class Animations:
 				self._setPixel(index, color)
 
 
-	def blink(self, color, minBrightness, maxBrightness, speed=200, repeat=-1):
+	def blink(self, color, minBrightness, maxBrightness, speed=200, repeat=-1, smooth=True):
 		"""
 		:param color: array RBGW
 		:param minBrightness: int
@@ -302,6 +302,9 @@ class Animations:
 			while bri < maxBrightness:
 				bri = self._image[0][3]
 
+				if not smooth:
+					bri = maxBrightness
+
 				for i in range(self._numLeds):
 					self._image[i] = color[0], color[1], color[2], bri + 1
 
@@ -310,6 +313,9 @@ class Animations:
 
 			while bri > minBrightness:
 				bri = self._image[0][3]
+
+				if not smooth:
+					bri = minBrightness
 
 				for i in range(self._numLeds):
 					self._image[i] = color[0], color[1], color[2], bri - 1

--- a/models/Animations.py
+++ b/models/Animations.py
@@ -20,8 +20,35 @@ class Animations:
 		else:
 			self._image = [[0, 0, 0, 0] for _ in range(self._numLeds)]
 
+	def wheelOverlap(self, colors, brightness=255, speed=100, duration=0):
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.wheelOverlap,
+				duration=duration,
+				colors=colors,
+				brightness=brightness,
+				speed=speed
+			)
 
-	def rainbow(self, brightness=255, speed=100):
+		self._animationFlag.set()
+
+		while self._animationFlag.isSet():
+			for color in colors:
+				for ledX in range(0, self._numLeds):
+					self._controller.setLedRGB(ledX, [color[0], color[1], color[2]], brightness)
+					time.sleep(1.0 / abs(speed))
+					self._controller.show()
+
+
+	def rainbow(self, brightness=255, speed=100, duration=0):
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.rainbow,
+				duration=duration,
+				brightness=brightness,
+				speed=speed
+			)
+
 		rainbowColors = [
 			[255, 0, 0], 	# RED
 			[255, 127, 0], 	# ORANGE
@@ -35,17 +62,10 @@ class Animations:
 			[255, 0, 127],	# FUCHSIA
 		]
 
-		self._animationFlag.set()
-
-		while self._animationFlag.isSet():
-			for color in rainbowColors:
-				for ledX in range(0, self._numLeds):
-					self._controller.setLedRGB(ledX, [color[0], color[1], color[2]], brightness)
-					time.sleep(1.0 / abs(speed))
-					self._controller.show()
+		self.wheelOverlap(colors=rainbowColors, brightness=brightness, speed=100)
 
 
-	def doubleSidedFilling(self, color, startAt=0, direction=1, speed=10):
+	def doubleSidedFilling(self, color, startAt=0, direction=1, speed=10, new=True, duration=0):
 		"""
 		Fills the strip from both sides
 		:param startAt: int
@@ -55,7 +75,20 @@ class Animations:
 		:param startAt: int, the led index where the animation starts
 		:return:
 		"""
-		self.new()
+
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.doubleSidedFilling,
+				duration=duration,
+				color=color,
+				startAt=startAt,
+				direction=direction,
+				speed=speed,
+				new=new
+			)
+
+		if new:
+			self.new()
 
 		r = range(int(round(self._numLeds / 2)) + 1)
 		if direction <= 0:
@@ -77,7 +110,7 @@ class Animations:
 			time.sleep(1.0 / abs(speed))
 
 
-	def breath(self, color, minBrightness, maxBrightness, speed=10):
+	def breath(self, color, minBrightness, maxBrightness, speed=10, duration=0):
 		"""
 		Breathes the leds, from min to max brightness
 		:param color: array RBGW
@@ -86,6 +119,16 @@ class Animations:
 		:param maxBrightness: int
 		:return:
 		"""
+
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.breath,
+				duration=duration,
+				color=color,
+				minBrightness=minBrightness,
+				maxBrightness=maxBrightness,
+				speed=speed
+			)
 
 		image = [color for _ in range(self._numLeds)]
 
@@ -127,7 +170,7 @@ class Animations:
 		self._displayImage()
 
 
-	def rotate(self, color, speed=10, trail=0, startAt=0):
+	def rotate(self, color, speed=10, trail=0, startAt=0, duration=0):
 		"""
 		Makes a light circulate your strip
 		:param color: list, an array containing RGB or RGBW informations
@@ -135,6 +178,16 @@ class Animations:
 		:param trail: int, if greater than 0, leave a trail behind the moving light, with decreased brightness
 		:param startAt: int, the led index where the animation starts
 		"""
+
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.rotate,
+				duration=duration,
+				color=color,
+				trail=trail,
+				startAt=startAt,
+				speed=speed
+			)
 
 		if trail > self._numLeds or trail < 0:
 			self._logger.error("Trail can't be longer than amount of leds")
@@ -165,7 +218,7 @@ class Animations:
 			self.rotateImage(rotationSign)
 
 
-	def relayRace(self, color, relayColor, backgroundColor=None, speed=10, startAt=0):
+	def relayRace(self, color, relayColor, backgroundColor=None, speed=10, startAt=0, duration=0):
 		"""
 		:param color: array RGBW
 		:param relayColor: array RGBW
@@ -173,6 +226,18 @@ class Animations:
 		:param speed: float, in l/s or led per second
 		:param startAt: int, the led index where the animation starts
 		"""
+
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.relayRace,
+				duration=duration,
+				color=color,
+				relayColor=relayColor,
+				backgroundColor=backgroundColor,
+				startAt=startAt,
+				speed=speed
+			)
+
 		if backgroundColor is None:
 			backgroundColor = [0, 0, 0, 0]
 
@@ -202,7 +267,7 @@ class Animations:
 			index = self._normalizeIndex(index + speedIncrement)
 
 
-	def doublePingPong(self, color, speed=10, backgroundColor=None, startAt=0):
+	def doublePingPong(self, color, speed=10, backgroundColor=None, startAt=0, duration=0):
 		"""
 		Makes two balls ping pong
 		:param color: array RBGW
@@ -211,6 +276,16 @@ class Animations:
 		:param startAt: int, the led index where the animation starts
 		:return:
 		"""
+
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.doublePingPong,
+				duration=duration,
+				color=color,
+				backgroundColor=backgroundColor,
+				startAt=startAt,
+				speed=speed
+			)
 
 		self.new()
 
@@ -249,7 +324,7 @@ class Animations:
 				self._setPixel(rightIndex, backgroundColor)
 
 
-	def waitWheel(self, color, speed=10, backgroundColor=None, startAt=0):
+	def waitWheel(self, color, speed=10, backgroundColor=None, startAt=0, duration=0):
 		"""
 		Makes two balls ping pong
 		:param color: array RBGW
@@ -258,6 +333,17 @@ class Animations:
 		:param startAt: int, the led index where the animation starts
 		:return:
 		"""
+
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.waitWheel,
+				duration=duration,
+				color=color,
+				backgroundColor=backgroundColor,
+				startAt=startAt,
+				speed=speed
+			)
+
 		if backgroundColor is None:
 			backgroundColor = [0, 0, 0, 0]
 
@@ -278,7 +364,7 @@ class Animations:
 				self._setPixel(index, color)
 
 
-	def blink(self, color, minBrightness, maxBrightness, speed=200, repeat=-1, smooth=True):
+	def blink(self, color, minBrightness, maxBrightness, speed=200, repeat=-1, smooth=True, duration=0):
 		"""
 		:param color: array RBGW
 		:param minBrightness: int
@@ -288,8 +374,20 @@ class Animations:
 		:return:
 		"""
 
+		if duration:
+			return self._controller.putStickyPattern(
+				pattern=self.blink,
+				duration=duration,
+				color=color,
+				minBrightness=minBrightness,
+				maxBrightness=maxBrightness,
+				repeat=repeat,
+				smooth=smooth,
+				speed=speed
+			)
+
 		if repeat == -1:
-			self.breath(color=color, maxBrightness=maxBrightness, minBrightness=minBrightness, speed=speed)
+			self.breath(color=color, maxBrightness=maxBrightness, minBrightness=minBrightness, speed=speed, duration=duration)
 			return
 		
 		image = [color]*self._numLeds

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -436,7 +436,6 @@ class HermesLedControl:
 					self._logger.debug("On leds clear received but it wasn't for me")
 
 		elif message.topic == self._SUB_MANUAL_ANIMATIONS_SET:
-			self._ledsController.stickyAnimation = None
 			if siteId == self._me:
 				if self._params.debug:
 					self._logger.debug('On manual animation leds set triggered')
@@ -445,21 +444,30 @@ class HermesLedControl:
 					self._logger.error('Missing "animation" in payload for set manual animation leds')
 				else:
 					if 'duration' in payload:
-						threading.Timer(interval=int(payload['duration']), function=self._ledsController.off, args=[]).start()
+						threading.Timer(interval=int(payload['duration']), function=self._ledsController.idle, args=[]).start()
+
+					flush = 'flush' in payload and payload['flush']
+					sticky = 'sticky' in payload and payload['sticky']
+					clear = 'clear' in payload and payload['clear']
+
+					if clear:
+						self._ledsController.stickyAnimation = None
 
 					if payload['animation'] == 'breath':
-						self._ledsController._put(
-							func=self._ledsController.pattern.animator.breath,
-							flush='flush' in payload,
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.breath,
+							sticky=sticky,
+							flush=flush,
 							color = self.safePayloadColor(payload, 'color'),
 							minBrightness = self.safePayloadNumber(payload, 'minBrightness', 2),
 							maxBrightness = self.safePayloadNumber(payload, 'maxBrightness', 20),
 							speed = self.safePayloadNumber(payload, 'speed', 40)
 						)
 					elif payload['animation'] == 'blink':
-						self._ledsController._put(
-							func=self._ledsController.pattern.animator.blink,
-							flush='flush' in payload,
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.blink,
+							sticky=sticky,
+							flush=flush,
 							color = self.safePayloadColor(payload, 'color'),
 							minBrightness = self.safePayloadNumber(payload, 'minBrightness', 2),
 							maxBrightness = self.safePayloadNumber(payload, 'maxBrightness', 20),
@@ -467,45 +475,50 @@ class HermesLedControl:
 							repeat = self.safePayloadNumber(payload, 'repeat', 3)
 						)
 					elif payload['animation'] == 'rotate':
-						self._ledsController._put(
-							func=self._ledsController.pattern.animator.rotate,
-							flush='flush' in payload,
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.rotate,
+							sticky=sticky,
+							flush=flush,
 							color = self.safePayloadColor(payload, 'color'),
 							speed = self.safePayloadNumber(payload, 'speed', 20),
 							trail = self.safePayloadNumber(payload, 'trail', 1),
 							startAt = self.safePayloadNumber(payload, 'startAt', 0)
 						)
 					elif payload['animation'] == 'doubleSidedFilling':
-						self._ledsController._put(
-							func=self._ledsController.pattern.animator.doubleSidedFilling,
-							flush='flush' in payload,
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.doubleSidedFilling,
+							sticky=sticky,
+							flush=flush,
 							color = self.safePayloadColor(payload, 'color'),
 							startAt = self.safePayloadNumber(payload, 'startAt', 0),
 							direction = self.safePayloadNumber(payload, 'direction', 1),
 							speed = self.safePayloadNumber(payload, 'speed', 50)
 						)
 					elif payload['animation'] == 'doublePingPong':
-						self._ledsController._put(
-							func=self._ledsController.pattern.animator.doublePingPong,
-							flush='flush' in payload,
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.doublePingPong,
+							sticky=sticky,
+							flush=flush,
 							color = self.safePayloadColor(payload, 'color'),
 							speed = self.safePayloadNumber(payload, 'speed', 20),
 							backgroundColor = self.safePayloadColor(payload, 'backgroundColor'),
 							startAt = self.safePayloadNumber(payload, 'startAt', 0)
 						)
 					elif payload['animation'] == 'waitWheel':
-						self._ledsController._put(
-							func=self._ledsController.pattern.animator.waitWheel,
-							flush='flush' in payload,
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.waitWheel,
+							sticky=sticky,
+							flush=flush,
 							color = self.safePayloadColor(payload, 'color'),
 							speed = self.safePayloadNumber(payload, 'speed', 20),
 							backgroundColor = self.safePayloadColor(payload, 'backgroundColor'),
 							startAt = self.safePayloadNumber(payload, 'startAt', 0)
 						)
 					elif payload['animation'] == 'relayRace':
-						self._ledsController._put(
-							func=self._ledsController.pattern.animator.relayRace,
-							flush='flush' in payload,
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.relayRace,
+							sticky=sticky,
+							flush=flush,
 							color = self.safePayloadColor(payload, 'color'),
 							relayColor = self.safePayloadColor(payload, 'relayColor'),
 							backgroundColor = self.safePayloadColor(payload, 'backgroundColor'),

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -512,7 +512,8 @@ class HermesLedControl:
 							color=self.safePayloadColor(payload, 'color'),
 							startAt=self.safePayloadNumber(payload, 'startAt', 0),
 							direction=self.safePayloadNumber(payload, 'direction', 1),
-							speed=self.safePayloadNumber(payload, 'speed', 50)
+							speed=self.safePayloadNumber(payload, 'speed', 50),
+							new=payload.get('new', True)
 						)
 					elif payload['animation'] == 'doublePingPong':
 						self._ledsController.putStickyPattern(

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -226,7 +226,7 @@ class HermesLedControl:
 			return False
 		
 		siteId = payload.get('siteId')
-		sticky = 'sticky' in payload
+		sticky = payload.get('sticky', False)
 		isForMe = siteId == self._me or siteId == self.ALL_SITE_ID
 
 		if self._hotwordRegex.match(message.topic):
@@ -461,12 +461,9 @@ class HermesLedControl:
 				if 'animation' not in payload:
 					self._logger.error('Missing "animation" in payload for set manual animation leds')
 				else:
-					if 'duration' in payload:
-						threading.Timer(interval=int(payload['duration']), function=self._ledsController.idle, args=[]).start()
-
 					flush = 'flush' in payload and payload['flush']
-					sticky = 'sticky' in payload and payload['sticky']
 					clear = 'clear' in payload and payload['clear']
+					duration = self.safePayloadNumber(payload, 'duration', 0)
 
 					if clear:
 						self._ledsController.stickyAnimation = None
@@ -475,73 +472,89 @@ class HermesLedControl:
 						self._ledsController.putStickyPattern(
 							pattern=self._ledsController.pattern.animator.breath,
 							sticky=sticky,
+							duration=duration,
 							flush=flush,
-							color = self.safePayloadColor(payload, 'color'),
-							minBrightness = self.safePayloadNumber(payload, 'minBrightness', 2),
-							maxBrightness = self.safePayloadNumber(payload, 'maxBrightness', 20),
-							speed = self.safePayloadNumber(payload, 'speed', 40)
+							color=self.safePayloadColor(payload, 'color'),
+							minBrightness=self.safePayloadNumber(payload, 'minBrightness', 2),
+							maxBrightness=self.safePayloadNumber(payload, 'maxBrightness', 20),
+							speed=self.safePayloadNumber(payload, 'speed', 40)
 						)
 					elif payload['animation'] == 'blink':
 						self._ledsController.putStickyPattern(
 							pattern=self._ledsController.pattern.animator.blink,
 							sticky=sticky,
+							duration=duration,
 							flush=flush,
-							color = self.safePayloadColor(payload, 'color'),
-							minBrightness = self.safePayloadNumber(payload, 'minBrightness', 2),
-							maxBrightness = self.safePayloadNumber(payload, 'maxBrightness', 20),
-							speed = self.safePayloadNumber(payload, 'speed', 300),
-							repeat = self.safePayloadNumber(payload, 'repeat', 3)
+							color=self.safePayloadColor(payload, 'color'),
+							minBrightness=self.safePayloadNumber(payload, 'minBrightness', 2),
+							maxBrightness=self.safePayloadNumber(payload, 'maxBrightness', 20),
+							speed=self.safePayloadNumber(payload, 'speed', 300),
+							repeat=self.safePayloadNumber(payload, 'repeat', 3)
 						)
 					elif payload['animation'] == 'rotate':
 						self._ledsController.putStickyPattern(
 							pattern=self._ledsController.pattern.animator.rotate,
 							sticky=sticky,
+							duration=duration,
 							flush=flush,
-							color = self.safePayloadColor(payload, 'color'),
-							speed = self.safePayloadNumber(payload, 'speed', 20),
-							trail = self.safePayloadNumber(payload, 'trail', 1),
-							startAt = self.safePayloadNumber(payload, 'startAt', 0)
+							color=self.safePayloadColor(payload, 'color'),
+							speed=self.safePayloadNumber(payload, 'speed', 20),
+							trail=self.safePayloadNumber(payload, 'trail', 1),
+							startAt=self.safePayloadNumber(payload, 'startAt', 0)
 						)
 					elif payload['animation'] == 'doubleSidedFilling':
 						self._ledsController.putStickyPattern(
 							pattern=self._ledsController.pattern.animator.doubleSidedFilling,
 							sticky=sticky,
+							duration=duration,
 							flush=flush,
-							color = self.safePayloadColor(payload, 'color'),
-							startAt = self.safePayloadNumber(payload, 'startAt', 0),
-							direction = self.safePayloadNumber(payload, 'direction', 1),
-							speed = self.safePayloadNumber(payload, 'speed', 50)
+							color=self.safePayloadColor(payload, 'color'),
+							startAt=self.safePayloadNumber(payload, 'startAt', 0),
+							direction=self.safePayloadNumber(payload, 'direction', 1),
+							speed=self.safePayloadNumber(payload, 'speed', 50)
 						)
 					elif payload['animation'] == 'doublePingPong':
 						self._ledsController.putStickyPattern(
 							pattern=self._ledsController.pattern.animator.doublePingPong,
 							sticky=sticky,
+							duration=duration,
 							flush=flush,
-							color = self.safePayloadColor(payload, 'color'),
-							speed = self.safePayloadNumber(payload, 'speed', 20),
-							backgroundColor = self.safePayloadColor(payload, 'backgroundColor'),
-							startAt = self.safePayloadNumber(payload, 'startAt', 0)
+							color=self.safePayloadColor(payload, 'color'),
+							speed=self.safePayloadNumber(payload, 'speed', 20),
+							backgroundColor=self.safePayloadColor(payload, 'backgroundColor'),
+							startAt=self.safePayloadNumber(payload, 'startAt', 0)
 						)
 					elif payload['animation'] == 'waitWheel':
 						self._ledsController.putStickyPattern(
 							pattern=self._ledsController.pattern.animator.waitWheel,
 							sticky=sticky,
+							duration=duration,
 							flush=flush,
-							color = self.safePayloadColor(payload, 'color'),
-							speed = self.safePayloadNumber(payload, 'speed', 20),
-							backgroundColor = self.safePayloadColor(payload, 'backgroundColor'),
-							startAt = self.safePayloadNumber(payload, 'startAt', 0)
+							color=self.safePayloadColor(payload, 'color'),
+							speed=self.safePayloadNumber(payload, 'speed', 20),
+							backgroundColor=self.safePayloadColor(payload, 'backgroundColor'),
+							startAt=self.safePayloadNumber(payload, 'startAt', 0)
 						)
 					elif payload['animation'] == 'relayRace':
 						self._ledsController.putStickyPattern(
 							pattern=self._ledsController.pattern.animator.relayRace,
 							sticky=sticky,
+							duration=duration,
 							flush=flush,
-							color = self.safePayloadColor(payload, 'color'),
-							relayColor = self.safePayloadColor(payload, 'relayColor'),
-							backgroundColor = self.safePayloadColor(payload, 'backgroundColor'),
-							speed = self.safePayloadNumber(payload, 'speed', 20),
-							startAt = self.safePayloadNumber(payload, 'startAt', 0)
+							color=self.safePayloadColor(payload, 'color'),
+							relayColor=self.safePayloadColor(payload, 'relayColor'),
+							backgroundColor=self.safePayloadColor(payload, 'backgroundColor'),
+							speed=self.safePayloadNumber(payload, 'speed', 20),
+							startAt=self.safePayloadNumber(payload, 'startAt', 0)
+						)
+					elif payload['animation'] == 'rainbow':
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.rainbow,
+							sticky=sticky,
+							duration=duration,
+							flush=flush,
+							brightness=self.safePayloadNumber(payload, 'brightness', 255),
+							speed=self.safePayloadNumber(payload, 'speed', 100)
 						)
 			else:
 				if self._params.debug:

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -489,7 +489,8 @@ class HermesLedControl:
 							minBrightness=self.safePayloadNumber(payload, 'minBrightness', 2),
 							maxBrightness=self.safePayloadNumber(payload, 'maxBrightness', 20),
 							speed=self.safePayloadNumber(payload, 'speed', 300),
-							repeat=self.safePayloadNumber(payload, 'repeat', 3)
+							repeat=self.safePayloadNumber(payload, 'repeat', 3),
+							smooth=payload.get('smooth', True)
 						)
 					elif payload['animation'] == 'rotate':
 						self._ledsController.putStickyPattern(

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -437,8 +437,7 @@ class HermesLedControl:
 			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On leds idle triggered')
-				else:
-					self._ledsController.idle()
+				self._ledsController.idle()
 			else:
 				if self._params.debug:
 					self._logger.debug("On leds idle received but it wasn't for me")

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -12,6 +12,8 @@ from models.LedsController import LedsController
 
 
 class HermesLedControl:
+	
+	ALL_SITE_ID = 'all'
 
 	_SUB_ON_HOTWORD 				= 'hermes/hotword/+/detected'
 	_SUB_ON_SAY 					= 'hermes/tts/say'
@@ -216,12 +218,17 @@ class HermesLedControl:
 		if hasattr(message, 'payload') and message.payload:
 			payload = json.loads(message.payload.decode('UTF-8'))
 
+		noLeds = payload.get('noLeds', False)
+		
+		if noLeds:
+			return False
+		
 		siteId = payload.get('siteId')
 		sticky = 'sticky' in payload
-
+		isForMe = siteId == self._me or siteId == self.ALL_SITE_ID
 
 		if self._hotwordRegex.match(message.topic):
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On hotword triggered')
 				self._ledsController.wakeup(sticky)
@@ -230,7 +237,7 @@ class HermesLedControl:
 					self._logger.debug("On hotword received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_LISTENING:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On listen triggered')
 				self._ledsController.listen(sticky)
@@ -239,7 +246,7 @@ class HermesLedControl:
 					self._logger.debug("On listen received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_SAY:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On say triggered')
 				self._ledsController.speak(sticky)
@@ -248,7 +255,7 @@ class HermesLedControl:
 					self._logger.debug("On say received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_THINK:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On think triggered')
 				self._ledsController.think(sticky)
@@ -257,7 +264,7 @@ class HermesLedControl:
 					self._logger.debug("On think received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_HOTWORD_TOGGLE_ON:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On hotword toggle on triggered')
 				self._ledsController.idle()
@@ -266,7 +273,7 @@ class HermesLedControl:
 					self._logger.debug("On hotword toggle on received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_TTS_FINISHED:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On tts finished triggered')
 				self._ledsController.idle()
@@ -275,7 +282,7 @@ class HermesLedControl:
 					self._logger.debug("On tts finished received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_PLAY_FINISHED:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On play finished triggered')
 				self._ledsController.idle()
@@ -284,7 +291,7 @@ class HermesLedControl:
 					self._logger.debug("On play finished received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_LEDS_TOGGLE_ON:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On leds toggle on triggered')
 				self._ledsController.toggleStateOn()
@@ -293,7 +300,7 @@ class HermesLedControl:
 					self._logger.debug("On leds toggle on received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_LEDS_TOGGLE_OFF:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On leds toggle off triggered')
 				self._ledsController.toggleStateOff()
@@ -302,7 +309,7 @@ class HermesLedControl:
 					self._logger.debug("On leds toggle off received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_LEDS_TOGGLE:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On leds toggle triggered')
 				self._ledsController.toggleState()
@@ -311,7 +318,7 @@ class HermesLedControl:
 					self._logger.debug("On leds toggle received but it wasn't for me")
 
 		elif message.topic == self._SUB_LEDS_ON_SUCCESS:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On success triggered')
 				self._ledsController.onSuccess(sticky)
@@ -320,7 +327,7 @@ class HermesLedControl:
 					self._logger.debug("On success received but it wasn't for me")
 
 		elif message.topic == self._SUB_LEDS_ON_ERROR:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On error triggered')
 				self._ledsController.onError(sticky)
@@ -329,7 +336,7 @@ class HermesLedControl:
 					self._logger.debug("On error received but it wasn't for me")
 
 		elif message.topic == self._SUB_UPDATING:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On updating triggered')
 				self._ledsController.updating(sticky)
@@ -338,7 +345,7 @@ class HermesLedControl:
 					self._logger.debug("On updating received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_CALL:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On call triggered')
 				self._ledsController.call(sticky)
@@ -347,7 +354,7 @@ class HermesLedControl:
 					self._logger.debug("On call received but it wasn't for me")
 
 		elif message.topic == self._SUB_SETUP_MODE:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On setup mode triggered')
 				self._ledsController.setupMode(sticky)
@@ -356,7 +363,7 @@ class HermesLedControl:
 					self._logger.debug("On setup mode received but it wasn't for me")
 
 		elif message.topic == self._SUB_CON_ERROR:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On connection error triggered')
 				self._ledsController.conError(sticky)
@@ -365,7 +372,7 @@ class HermesLedControl:
 					self._logger.debug("On connection error received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_MESSAGE:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On message triggered')
 				self._ledsController.message(sticky)
@@ -374,7 +381,7 @@ class HermesLedControl:
 					self._logger.debug("On message received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_DND:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On do not disturb triggered')
 				self._ledsController.dnd(sticky)
@@ -383,7 +390,7 @@ class HermesLedControl:
 					self._logger.debug("On do not disturb received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_START:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On start triggered')
 				self._ledsController.start()
@@ -392,7 +399,7 @@ class HermesLedControl:
 					self._logger.debug("On start received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_STOP:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On stop triggered')
 				self._ledsController.stop()
@@ -401,7 +408,7 @@ class HermesLedControl:
 					self._logger.debug("On stop received but it wasn't for me")
 
 		elif message.topic == self._SUB_VOLUME_SET:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On volume set triggered')
 				if 'volume' not in payload:
@@ -413,7 +420,7 @@ class HermesLedControl:
 					self._logger.debug("On volume set received but it wasn't for me")
 
 		elif message.topic == self._SUB_VADLED_SET:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On vad led set triggered')
 				if 'state' not in payload:
@@ -426,7 +433,7 @@ class HermesLedControl:
 
 		elif message.topic == self._SUB_ON_LEDS_CLEAR:
 			self._ledsController.stickyAnimation = None
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On leds clear triggered')
 				else:
@@ -436,7 +443,7 @@ class HermesLedControl:
 					self._logger.debug("On leds clear received but it wasn't for me")
 
 		elif message.topic == self._SUB_MANUAL_ANIMATIONS_SET:
-			if siteId == self._me:
+			if isForMe:
 				if self._params.debug:
 					self._logger.debug('On manual animation leds set triggered')
 

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -557,6 +557,16 @@ class HermesLedControl:
 							brightness=self.safePayloadNumber(payload, 'brightness', 255),
 							speed=self.safePayloadNumber(payload, 'speed', 100)
 						)
+					elif payload['animation'] == 'wheelOverlap':
+						self._ledsController.putStickyPattern(
+							pattern=self._ledsController.pattern.animator.wheelOverlap,
+							sticky=sticky,
+							duration=duration,
+							flush=flush,
+							colors=payload['colors'],
+							brightness=self.safePayloadNumber(payload, 'brightness', 255),
+							speed=self.safePayloadNumber(payload, 'speed', 100)
+						)
 			else:
 				if self._params.debug:
 					self._logger.debug("On manual animation leds received but it wasn't for me")

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -29,6 +29,7 @@ class HermesLedControl:
 	_SUB_ON_LEDS_TOGGLE_ON 			= 'hermes/leds/toggleOn'
 	_SUB_ON_LEDS_TOGGLE_OFF 		= 'hermes/leds/toggleOff'
 	_SUB_ON_LEDS_CLEAR 				= 'hermes/leds/clear'
+	_SUB_ON_LEDS_IDLE 				= 'hermes/leds/idle'
 	_SUB_UPDATING 					= 'hermes/leds/systemUpdate'
 	_SUB_ON_CALL 					= 'hermes/leds/onCall'
 	_SUB_SETUP_MODE 				= 'hermes/leds/setupMode'
@@ -205,6 +206,7 @@ class HermesLedControl:
 			(self._SUB_VOLUME_SET, 0),
 			(self._SUB_VADLED_SET, 0),
 			(self._SUB_ON_LEDS_CLEAR, 0),
+			(self._SUB_ON_LEDS_IDLE, 0),
 			(self._SUB_MANUAL_ANIMATIONS_SET, 0),
 		])
 
@@ -430,6 +432,16 @@ class HermesLedControl:
 			else:
 				if self._params.debug:
 					self._logger.debug("On vad led set received but it wasn't for me")
+	
+		elif message.topic == self._SUB_ON_LEDS_IDLE:
+			if isForMe:
+				if self._params.debug:
+					self._logger.debug('On leds idle triggered')
+				else:
+					self._ledsController.idle()
+			else:
+				if self._params.debug:
+					self._logger.debug("On leds idle received but it wasn't for me")
 
 		elif message.topic == self._SUB_ON_LEDS_CLEAR:
 			self._ledsController.stickyAnimation = None

--- a/models/HermesLedControl.py
+++ b/models/HermesLedControl.py
@@ -516,8 +516,12 @@ class HermesLedControl:
 				if self._params.debug:
 					self._logger.debug("On manual animation leds received but it wasn't for me")
 
+
 	def safePayloadColor(self, payload, attributeName, default=None):
 		color = payload.get(attributeName, [255, 255, 255, 2] if not default else default)
+
+		if type(color) == str and ',' in color:
+			color = [int(c) for c in color.split(",")]
 
 		if len(color) == 3:
 			self._logger.warning(f"Missing white channel in '{attributeName}' attribute (RGBW format), appending default value")

--- a/models/LedPattern.py
+++ b/models/LedPattern.py
@@ -14,6 +14,11 @@ class LedPattern:
 
 
 	@property
+	def animator(self):
+		return self._animator
+
+
+	@property
 	def animation(self):
 		return self._animation
 

--- a/models/LedsController.py
+++ b/models/LedsController.py
@@ -109,6 +109,11 @@ class LedsController:
 		return self._interface
 
 
+	@property
+	def pattern(self):
+		return self._pattern
+
+
 	def initHardware(self):
 		try:
 			if self._hardware['interface'] == Interfaces.APA102:
@@ -312,7 +317,7 @@ class LedsController:
 			self.toggleStateOn()
 
 
-	def _put(self, func, flush=False):
+	def _put(self, func, flush=False, **kwargs):
 		self._pattern.animation.clear()
 
 		if not self.active:
@@ -321,14 +326,14 @@ class LedsController:
 		if flush:
 			self._queue.empty()
 
-		self._queue.put(func)
+		self._queue.put({"func": func, "args": kwargs})
 
 
 	def _runAnimation(self):
 		while self._running:
 			self._pattern.animation.clear()
-			func = self._queue.get()
-			func()
+			funcRecipe = self._queue.get()
+			funcRecipe['func'](**funcRecipe['args'])
 
 
 	def setLed(self, ledNum, red, green, blue, brightness=-1):

--- a/models/LedsController.py
+++ b/models/LedsController.py
@@ -180,19 +180,19 @@ class LedsController:
 			self._logger.warning('Tried to set vad led on an unsupported device')
 
 
-	def putStickyPattern(self, pattern, patternMethod, sticky):
+	def putStickyPattern(self, pattern, patternMethod = None, sticky: bool = False, flush: bool = False, **kwargs):
 		if sticky:
-			self._stickyAnimation = pattern
+			self._stickyAnimation = {"func": pattern, "args": kwargs}
 
 		if patternMethod is None:
-			self._put(pattern)
+			self._put(pattern, flush=flush, **kwargs)
 		else:
 			try:
 				func = getattr(self._pattern, patternMethod)
-				self._put(func)
+				self._put(func, flush=flush, **kwargs)
 			except AttributeError:
 				self._logger.error("Can't find {} method in pattern".format(patternMethod))
-				self._put(pattern)
+				self._put(pattern, flush=flush, **kwargs)
 
 
 	def wakeup(self, sticky: bool = False):
@@ -213,7 +213,7 @@ class LedsController:
 
 	def idle(self):
 		if self._stickyAnimation:
-			self._put(self._stickyAnimation)
+			self._put(self._stickyAnimation['func'], flush=False, **self._stickyAnimation['args'])
 		else:
 			if self._params.idlePattern is None:
 				self._put(self._pattern.idle)


### PR DESCRIPTION
**Examples:**

# Custom animations
topic: `hermes/leds/manual/animations`
```json
{
"siteId": "default", 
"animation": "breath", 
"color": [255,255,0]
}
```

# All sites at once with duration

topic: `hermes/leds/manual/animations`
```json
{
"siteId": "all", 
"animation": "blink", 
"color": [255,255,0],
"duration": 10
}
```

# No led flags to prevent HLC from switching LEDs on for `hermes/tts/say`

topic: `hermes/tts/say`
```json
{
"text": "Some stealth TTS output",
"siteId": "all", 
"noLeds": true
}
```