### PR TITLE
Bad brightness api usage, bad "breath" animations

### DIFF
--- a/interfaces/respeakerMicArrayV2.py
+++ b/interfaces/respeakerMicArrayV2.py
@@ -48,7 +48,7 @@ class RespeakerMicArrayV2(Interface):
 	def onStop(self):
 		super().onStop()
 		self.clearStrip()
-		self._leds.cleanup()
+		self._leds.close()
 		if self._src:
 			self._src.recursive_stop()
 

--- a/interfaces/respeakerMicArrayV2.py
+++ b/interfaces/respeakerMicArrayV2.py
@@ -62,7 +62,7 @@ class RespeakerMicArrayV2(Interface):
 		self._colors[index] = red
 		self._colors[index + 1] = green
 		self._colors[index + 2] = blue
-		self._colors[index + 3] = brightness
+		self._colors[index + 3] = 255 if red == 0 and green == 0 and blue == 0 else brightness
 
 
 	def setPixelRgb(self, ledNum, color, brightness):

--- a/interfaces/respeakerMicArrayV2.py
+++ b/interfaces/respeakerMicArrayV2.py
@@ -76,8 +76,6 @@ class RespeakerMicArrayV2(Interface):
 
 	def show(self):
 		self._leds.customize(self._colors)
-		self._leds.set_brightness(self._colors[3])
-		
 
 
 	def setVolume(self, volume):

--- a/interfaces/respeakerMicArrayV2.py
+++ b/interfaces/respeakerMicArrayV2.py
@@ -76,6 +76,8 @@ class RespeakerMicArrayV2(Interface):
 
 	def show(self):
 		self._leds.customize(self._colors)
+		self._leds.set_brightness(self._colors[3])
+		
 
 
 	def setVolume(self, volume):

--- a/libraries/usb_pixel_ring_v2.py
+++ b/libraries/usb_pixel_ring_v2.py
@@ -43,6 +43,7 @@ class PixelRing:
 
 	def show(self, data):
 		self.write(6, data)
+		self.set_brightness(data[3])
 
 	customize = show
 


### PR DESCRIPTION
This problem only affects respeakerMicArrayV2

According to this documentation: https://github.com/respeaker/pixel_ring/wiki/ReSpeaker-USB-4-Mic-Array-LED-Control-Protocol

*Problem:* You can't change brightness for each leds individually. The `show` method of `pixel_ring` uses a `0x06` command which controls `[r, g, b, 0] * 12` with `0` meaning constant max brightness.

*Solution:* To control the brightness, you have to use the command `0x20` instead.
The fix is very simple, we just take the brightness of the first LED (among all image leds).

Tested and working.