### PR TITLE
Bad doubleSidedFilling effect on reverse direction

### DIFF
--- a/ledPatterns/ProjectAlicePattern.py
+++ b/ledPatterns/ProjectAlicePattern.py
@@ -28,9 +28,9 @@ class ProjectAlicePattern(LedPattern):
 		self.off()
 		self._animator.doubleSidedFilling(color=[255, 255, 255, 15], startAt=start, direction=1, speed=50)
 		time.sleep(0.1)
-		self._animator.doubleSidedFilling(color=[0, 0, 255, 25], startAt=start, direction=-1, speed=50)
+		self._animator.doubleSidedFilling(color=[0, 0, 255, 25], startAt=start, direction=-1, speed=50, new=False)
 		time.sleep(0.2)
-		self._animator.doubleSidedFilling(color=[0, 0, 0, 0], startAt=start, direction=1, speed=50)
+		self._animator.doubleSidedFilling(color=[0, 0, 0, 0], startAt=start, direction=1, speed=50, new=False)
 
 
 	def listen(self, *args):

--- a/models/Animations.py
+++ b/models/Animations.py
@@ -21,7 +21,7 @@ class Animations:
 			self._image = [[0, 0, 0, 0] for _ in range(self._numLeds)]
 
 
-	def doubleSidedFilling(self, color, startAt=0, direction=1, speed=10):
+	def doubleSidedFilling(self, color, startAt=0, direction=1, speed=10, new=True):
 		"""
 		Fills the strip from both sides
 		:param startAt: int
@@ -31,7 +31,8 @@ class Animations:
 		:param startAt: int, the led index where the animation starts
 		:return:
 		"""
-		self.new()
+		if new:
+			self.new()
 
 		r = range(int(round(self._numLeds / 2)) + 1)
 		if direction <= 0:


### PR DESCRIPTION
The doubleSidedFilling wasn't fulfilled gracefully due to the cleaning of all leds each time this animation was played.
