### PR TITLE
Added default value to host parameter #84

### DIFF
--- a/models/engines/Rhasspy.py
+++ b/models/engines/Rhasspy.py
@@ -42,7 +42,7 @@ class Rhasspy:
 				conf = json.load(confFile)
 
 				try:
-					configs['mqttServer'] = conf['mqtt']['host']
+					configs['mqttServer'] = conf['mqtt'].get('host', 'localhost')
 					configs['mqttPort'] = conf['mqtt'].get('port', 1883)
 					configs['mqttUsername'] = conf['mqtt'].get('username', '')
 					configs['mqttPassword'] = conf['mqtt'].get('password', '')


### PR DESCRIPTION
As Rhasspy removes parameters with defaultvalues from the profile.json localhost should be the fallback when no value is declared.