### PR TITLE
Changed driver repository to HinTak

### DIFF
--- a/installers/respeakers.sh
+++ b/installers/respeakers.sh
@@ -13,7 +13,7 @@ EOF
 cd /home/${USER}
 rm -rf /home/${USER}/seeed-voicecard
 
-git clone https://github.com/respeaker/seeed-voicecard.git
+git clone https://github.com/HinTak/seeed-voicecard.git
 cd seeed-voicecard
 chmod +x ./install.sh
 ./install.sh


### PR DESCRIPTION
Use the HinTak driver repository, to avoid kernel downgrade and because it is actually maintained, as compared to the respecter one.