### PR TITLE
Add missing logging import in models/LedPattern.py

### DIFF
--- a/models/LedPattern.py
+++ b/models/LedPattern.py
@@ -1,5 +1,5 @@
 import colorsys
-
+import logging
 from models.Animations import Animations
 from models.LedsController import *
 


### PR DESCRIPTION
Hello,
when starting the latest version of hermesLedControl, I'll get a NameError due to the miossing import: 

Traceback (most recent call last):
  File "main.py", line 63, in <module>
    main()
  File "main.py", line 48, in main
    slc = HermesLedControl(args)
  File "/opt/hermesLedControl/models/HermesLedControl.py", line 134, in __init__
    self._ledsController = LedsController(self)
  File "/opt/hermesLedControl/models/LedsController.py", line 59, in __init__
    self._pattern = AlexaLedPattern(self)
  File "/opt/hermesLedControl/ledPatterns/AlexaLedPattern.py", line 8, in __init__
    super(AlexaLedPattern, self).__init__(controller)
  File "/opt/hermesLedControl/models/LedPattern.py", line 10, in __init__
    self._logger                                = logging.getLogger('HermesLedControl')
NameError: name 'logging' is not defined
